### PR TITLE
clean up sankey prototype scripty

### DIFF
--- a/evals/constants.py
+++ b/evals/constants.py
@@ -8,10 +8,8 @@ Collect constant values and identifiers used for evaluations.
 Values in this module do not need to be changed during runtime.
 """
 
-import importlib
 import re
 from datetime import datetime as dt
-from importlib.metadata import PackageNotFoundError
 from subprocess import CalledProcessError
 
 import git
@@ -792,17 +790,14 @@ ALIAS_LOCATION_REV: frozendict = frozendict({v: k for k, v in ALIAS_LOCATION.ite
 
 
 try:
-    esmtools_version = importlib.metadata.version("esmtools")
-except PackageNotFoundError:
-    esmtools_version = "esmtools not installed."
-
-try:
     repo = git.Repo(search_parent_directories=True)
     branch = repo.active_branch.name
     repo_name = repo.remotes.origin.url.split(".git")[0].split("/")[-1]
     git_hash = repo.head.object.hexsha
 except (CalledProcessError, FileNotFoundError):
     repo_name = branch = git_hash = "Not a git repo."
+except TypeError:
+    repo_name = branch = git_hash = "Detached HEAD"
 
 RUN_META_DATA = {
     "repo_name": repo_name,

--- a/evals/plots/sankey.py
+++ b/evals/plots/sankey.py
@@ -15,37 +15,13 @@ pd.set_option("display.width", 250)
 pd.set_option("display.max_columns", 20)
 
 
-def read_iamc_data_frame():
+def read_iamc_data_frame(filepath):
     xls = pd.read_excel(
-        "/IdeaProjects/pypsa-at/results/v2025.02/KN2045_Mix/evaluation/exported_iamc_variables.xlsx",
+        filepath,
         index_col=[0, 1, 2, 3, 4],
     )
     xls.columns.name = "Year"
     return xls.stack()
-
-
-def main():
-    year = "2050"
-    region = "GB0"
-
-    df = read_iamc_data_frame()
-    df = rename_aggregate(df, "TWh", level="Unit").div(1e6)
-    df = filter_by(df, Year=year, Region=region)
-
-    raw_mapping = get_mapping(df)
-    variables = df.index.unique("Variable")
-    for k, v in raw_mapping.items():
-        if k in variables:
-            clean_mapping[k] = v
-        else:
-            print(f"Skipping '{k}' because it does not exist in {region} {year}.")
-
-    iamc = pyam.IamDataFrame(df)
-    fig = iamc.plot.sankey(mapping=clean_mapping)
-
-    fig.update_layout(height=600)
-
-    plotly.io.show(fig)
 
 
 def get_mapping(df) -> (dict, set):
@@ -147,14 +123,15 @@ def get_xmap(nodes) -> dict:
 
 
 if __name__ == "__main__":
-    FILEPATH = "/IdeaProjects/pypsa-at/results/v2025.02/KN2045_Mix/evaluation/exported_iamc_variables.xlsx"
-    df = read_iamc_data_frame()
+    df = read_iamc_data_frame(
+        filepath="/IdeaProjects/pypsa-at/results/v2025.03/AT10_KN2040/evaluation/exported_iamc_variables.xlsx"
+    )
     mapping, nodes = get_mapping(df)
     mapping_sorted = {k: mapping[k] for k in sorted(mapping, key=sort_mapping)}
     xmap = get_xmap(nodes)
     df = rename_aggregate(df, "TWh", level="Unit").div(1e6)
     year = "2050"
-    region = "GB0"
+    region = "FR0"
     df = filter_by(df, Year=year, Region=region)
 
     clean_mapping = {}
@@ -173,8 +150,6 @@ if __name__ == "__main__":
 
     node["x"] = [xmap.get(label, 0.2) for label in node["label"]]
     node["y"] = [xmap.get(label, 0.4) for label in node["label"]]
-    # node["y"] = [ymap[label] for label in node["label"]]
-    # node["color"] = [colormap[label] for label in node["label"]]
 
     new_sankey = Sankey(
         node=node,
@@ -184,6 +159,6 @@ if __name__ == "__main__":
 
     fig = Figure(data=[new_sankey])
 
-    fig.update_layout(height=600)
+    fig.update_layout(height=800)
 
     plotly.io.show(fig)


### PR DESCRIPTION
Simple test PR

## Summary by Sourcery

Refactor sankey.py to remove hardcoded values, simplify its entry point, update defaults, and refine the figure layout.

Enhancements:
- Parameterize read_iamc_data_frame with a filepath argument to remove hardcoded paths
- Remove the standalone main() function and streamline the __main__ entry point
- Update example invocation to use a new default filepath and switch region to FR0
- Adjust sankey figure layout by increasing the height to 800
- Clean up commented-out node positioning and coloring code