### PR TITLE
Enable multiple custom cost files

### DIFF
--- a/CHANGELOG.AT.md
+++ b/CHANGELOG.AT.md
@@ -35,6 +35,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Limit cross-country electricity flows by NTCs (TYNDP) ([#112](https://github.com/AGGM-AG/pypsa-at/pull/112))
 - Added H2 imports from countries that are not in the model based on tyndp data ([#126](https://github.com/AGGM-AG/pypsa-at/pull/126))
 - Added Know-How document for hydro power ([#135](https://github.com/AGGM-AG/pypsa-at/pull/135))
+- Added file list configuration for custom cost files ([#148](https://github.com/AGGM-AG/pypsa-at/pull/148))
 
 ### Changed
 - Blocked imports of Russian methane via Ukraine and TurkStream ([#129](https://github.com/AGGM-AG/pypsa-at/pull/129))

--- a/Snakefile
+++ b/Snakefile
@@ -113,6 +113,7 @@ if config["foresight"] == "perfect":
 
 include: "rules/pypsa-at/retrieve.smk"  # PyPSA-AT specific data retrieval
 include: "rules/pypsa-at/build.smk"  # PyPSA-AT specific data build rules
+include: "rules/pypsa-at/build_electricity.smk"  # PyPSA-AT specific electricity build rule patches
 include: "rules/pypsa-at/modify.smk"  # PyPSA-AT specific modifications and upstream rule overrides (must follow build_electricity.smk / build_sector.smk — it overrides rules defined there)
 include: "rules/pypsa-at/build_sector.smk"  # PyPSA-AT specific modifications for sector network
 include: "rules/pypsa-at/solve.smk"  # PyPSA-AT specific solve rule extensions

--- a/config/config.at.yaml
+++ b/config/config.at.yaml
@@ -48,7 +48,11 @@ clustering:
     resolution_sector: 365H
 
 costs:
+  use_list: true
   custom_cost_fn: data/custom_costs.csv
+  custom_cost_fn_list:
+    - data/custom_costs.csv
+    - data/pypsa-de/custom_costs_nep_2023.csv
 
 sector:
   v2g: false

--- a/config/config.at.yaml
+++ b/config/config.at.yaml
@@ -51,8 +51,8 @@ costs:
   use_list: false       # Whether to use the file custom_cost_fn or combine files from custom_cost_fn_list
   custom_cost_fn: data/custom_costs.csv
   custom_cost_fn_list:
-    - data/custom_costs.csv
-    - data/pypsa-de/custom_costs_nep_2023.csv
+  - data/custom_costs.csv
+  - data/pypsa-de/custom_costs_nep_2023.csv
 
 sector:
   v2g: false

--- a/config/config.at.yaml
+++ b/config/config.at.yaml
@@ -48,7 +48,7 @@ clustering:
     resolution_sector: 365H
 
 costs:
-  use_list: true
+  use_list: false       # Whether to use the file custom_cost_fn or combine files from custom_cost_fn_list
   custom_cost_fn: data/custom_costs.csv
   custom_cost_fn_list:
     - data/custom_costs.csv

--- a/rules/pypsa-at/build.smk
+++ b/rules/pypsa-at/build.smk
@@ -5,14 +5,17 @@
 """
 Build rules for AT-specific datasets.
 """
+
+
 rule build_custom_cost_fn:
     input:
-        custom_cost_files = branch(
+        custom_cost_files=branch(
             config_provider("costs", "use_list"),
             config_provider("costs", "custom_cost_fn_list"),
-            lambda w: [config_provider("costs", "custom_cost_fn")(w)])
+            lambda w: [config_provider("costs", "custom_cost_fn")(w)],
+        ),
     output:
-        custom_cost_fn = resources("custom_cost_fn.csv"),
+        custom_cost_fn=resources("custom_cost_fn.csv"),
     log:
         logs("build_custom_cost_fn.log"),
     benchmark:

--- a/rules/pypsa-at/build.smk
+++ b/rules/pypsa-at/build.smk
@@ -6,6 +6,11 @@
 Build rules for AT-specific datasets.
 """
 rule build_custom_cost_fn:
+    input:
+        custom_cost_files = branch(
+            config_provider("costs", "use_list"),
+            config_provider("costs", "custom_cost_fn_list"),
+            lambda w: [config_provider("costs", "custom_cost_fn")(w)])
     output:
         custom_cost_fn = resources("custom_cost_fn.csv"),
     log:

--- a/rules/pypsa-at/build.smk
+++ b/rules/pypsa-at/build.smk
@@ -5,6 +5,20 @@
 """
 Build rules for AT-specific datasets.
 """
+rule build_custom_cost_fn:
+    output:
+        custom_cost_fn = resources("custom_cost_fn.csv"),
+    log:
+        logs("build_custom_cost_fn.log"),
+    benchmark:
+        benchmarks("build_custom_cost_fn")
+    threads: 1
+    resources:
+        mem_mb=4000,
+    params:
+        costs=config_provider("costs"),
+    script:
+        scripts("pypsa-at/build_custom_cost_fn.py")
 
 
 rule build_tyndp_trajectories:

--- a/rules/pypsa-at/build_electricity.smk
+++ b/rules/pypsa-at/build_electricity.smk
@@ -6,11 +6,13 @@
 PyPSA-AT patch to electricity build rules.
 """
 
+
 use rule process_cost_data as process_cost_data_at with:
     input:
         **{
             **rules.process_cost_data.input,
-            "custom_costs": resources("custom_cost_fn.csv")
-          }
+            "custom_costs": resources("custom_cost_fn.csv"),
+        },
+
 
 ruleorder: process_cost_data_at > process_cost_data

--- a/rules/pypsa-at/build_electricity.smk
+++ b/rules/pypsa-at/build_electricity.smk
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 Austrian Gas Grid Management AG
+#
+# SPDX-License-Identifier: MIT
+# For license information, see the LICENSE.txt file in the project root.
+"""
+PyPSA-AT patch to electricity build rules.
+"""
+
+use rule process_cost_data as process_cost_data_at with:
+    input:
+        **{
+            **rules.process_cost_data.input,
+            "custom_costs": resources("custom_cost_fn.csv")
+          }
+
+ruleorder: process_cost_data_at > process_cost_data

--- a/scripts/lib/validation/config/costs.py
+++ b/scripts/lib/validation/config/costs.py
@@ -82,10 +82,7 @@ class CostsConfig(BaseModel):
         description="Whether to use the custom_costs_fn_list config for the creation of custom costs",
     )
     custom_cost_fn_list: list[str] | None = Field(
-        default=[
-            "data/custom_costs.csv",
-            "data/pypsa-de/custom_costs_nep_2023.csv"
-        ],
+        default=["data/custom_costs.csv", "data/pypsa-de/custom_costs_nep_2023.csv"],
         description="Path to the custom costs files. Default files contain minor adjustments for stabilising the optimisation results.",
     )
     overwrites: dict[str, dict[str, float]] = Field(

--- a/scripts/lib/validation/config/costs.py
+++ b/scripts/lib/validation/config/costs.py
@@ -77,6 +77,17 @@ class CostsConfig(BaseModel):
         "data/custom_costs.csv",
         description="Path to the custom costs file. None if it should not be used. Default `data/custom_costs.csv` contains minor adjustments for stabilising the optimisation results.",
     )
+    use_list: bool | None = Field(
+        True,
+        description="Whether to use the custom_costs_fn_list config for the creation of custom costs",
+    )
+    custom_cost_fn_list: list[str] | None = Field(
+        default=[
+            "data/custom_costs.csv",
+            "data/pypsa-de/custom_costs_nep_2023.csv"
+        ],
+        description="Path to the custom costs files. Default files contain minor adjustments for stabilising the optimisation results.",
+    )
     overwrites: dict[str, dict[str, float]] = Field(
         default_factory=dict,
         description="For the given parameters and technologies, assumptions about their parameter are overwritten the corresponding value of the technology.",

--- a/scripts/process_cost_data.py
+++ b/scripts/process_cost_data.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            "process_cost_data", planning_horizons=2030, run="AT_KN2040"
+            "process_cost_data_at", planning_horizons=2030, run="AT_KN2040"
         )
 
     cost_params = snakemake.params["costs"]

--- a/scripts/pypsa-at/build_custom_cost_fn.py
+++ b/scripts/pypsa-at/build_custom_cost_fn.py
@@ -3,15 +3,31 @@
 # SPDX-License-Identifier: MIT
 # For license information, see the LICENSE.txt file in the project root.
 """
-Prepares custom cost resource file based on costs config.
+Combine or export custom cost CSV files for energy system optimization.
 
-If costs.use_list is true then combines files given in costs.custom_cost_fn_list. If entries occur multiple times
-the first occurrence is kept.
-If costs.use_list is false custom_cost_fn is exported
+This script prepares a unified custom cost resource file based on the configuration.
+It supports two modes:
+
+1. **List mode** (``costs.use_list=true``): Combines multiple CSV files specified in
+   ``costs.custom_cost_fn_list``. When duplicate index entries exist (same
+   ``planning_horizon``, ``technology``, and ``parameter``), the first occurrence
+   is retained. This priority order respects the order of files in the config list.
+
+2. **Single file mode** (``costs.use_list=false``): Exports the single file specified
+   in ``costs.custom_cost_fn``.
+
+**Input format:**
+Each CSV file must have the following columns:
+- ``planning_horizon``: Year or horizon identifier (e.g. 2025, 2030, 2050)
+- ``technology``: Technology name (e.g. 'solar', 'methane pyrolysis plasma')
+- ``parameter``: Cost parameter (e.g. 'capital_cost', 'marginal_cost')
+- Additional columns: cost values and metadata
+
+**Output:**
+A single CSV file at ``resources/custom_cost_fn.csv`` with deduplicated entries.
 """
 
 import logging
-import shutil
 
 import pandas as pd
 from snakemake.script import Snakemake
@@ -20,23 +36,46 @@ from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
-def main(snakemake: Snakemake):
-    costs = snakemake.params.costs
-    if costs["use_list"]:
-        file_list = costs["custom_cost_fn_list"]
-        index_cols = ["planning_horizon", "technology", "parameter"]
-        cost_dfs = [
-            pd.read_csv(path).set_index(index_cols) for path in file_list
-        ]
-        combined = pd.concat(cost_dfs)
 
-        # Keep the first occurrence according to the order of `paths`.
-        # This also handles duplicate indices within an individual file.
-        combined = combined[~combined.index.duplicated(keep="first")]
-        pd.to_csv(snakemake.output.custom_cost_fn)
+def main(snakemake: Snakemake) -> None:
+    """
+    Combine multiple custom cost CSV files or export a single file.
 
-    else:
-        shutil.copyfile(costs["custom_cost_fn"], snakemake.output.custom_cost_fn)
+    When combining files (``costs.use_list=true``), concatenates all CSV files
+    specified in ``snakemake.input.custom_cost_files``, then deduplicates by
+    index (planning_horizon, technology, parameter), retaining the first occurrence.
+    This ensures earlier files in the list take priority over later ones.
+
+    Parameters
+    ----------
+    snakemake
+        Snakemake object
+
+    Returns
+    -------
+    :
+        Writes the deduplicated combined CSV to ``snakemake.output.custom_cost_fn``.
+
+    """
+    file_list = snakemake.input.custom_cost_files
+    index_cols = ["planning_horizon", "technology", "parameter"]
+
+    logger.info(f"Loading {len(file_list)} custom cost file(s)...")
+
+    cost_dfs = [pd.read_csv(path).set_index(index_cols) for path in file_list]
+
+    combined = pd.concat(cost_dfs)
+
+    # Remove duplicates, keeping the first occurrence. This respects the order
+    # of files in the input list: earlier files have higher priority.
+    # The keep="first" parameter also handles duplicates within individual files.
+    combined = combined[~combined.index.duplicated(keep="first")]
+
+    logger.info(
+        f"Writing custom cost file to {snakemake.output.custom_cost_fn}."
+    )
+
+    combined.to_csv(snakemake.output.custom_cost_fn)
 
 
 if __name__ == "__main__":

--- a/scripts/pypsa-at/build_custom_cost_fn.py
+++ b/scripts/pypsa-at/build_custom_cost_fn.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Austrian Gas Grid Management AG
+#
+# SPDX-License-Identifier: MIT
+# For license information, see the LICENSE.txt file in the project root.
+"""
+Prepares custom cost resource file based on costs config.
+
+If costs.use_list is true then combines files given in costs.custom_cost_fn_list. If entries occur multiple times
+the first occurrence is kept.
+If costs.use_list is false custom_cost_fn is exported
+"""
+
+import logging
+import shutil
+
+import pandas as pd
+from snakemake.script import Snakemake
+
+from scripts._helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+def main(snakemake: Snakemake):
+    costs = snakemake.params.costs
+    if costs["use_list"]:
+        file_list = costs["custom_cost_fn_list"]
+        index_cols = ["planning_horizon", "technology", "parameter"]
+        cost_dfs = [
+            pd.read_csv(path).set_index(index_cols) for path in file_list
+        ]
+        combined = pd.concat(cost_dfs)
+
+        # Keep the first occurrence according to the order of `paths`.
+        # This also handles duplicate indices within an individual file.
+        combined = combined[~combined.index.duplicated(keep="first")]
+        pd.to_csv(snakemake.output.custom_cost_fn)
+
+    else:
+        shutil.copyfile(costs["custom_cost_fn"], snakemake.output.custom_cost_fn)
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake("build_custom_cost_fn")
+
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+    main(snakemake)

--- a/scripts/pypsa-at/build_custom_cost_fn.py
+++ b/scripts/pypsa-at/build_custom_cost_fn.py
@@ -71,9 +71,7 @@ def main(snakemake: Snakemake) -> None:
     # The keep="first" parameter also handles duplicates within individual files.
     combined = combined[~combined.index.duplicated(keep="first")]
 
-    logger.info(
-        f"Writing custom cost file to {snakemake.output.custom_cost_fn}."
-    )
+    logger.info(f"Writing custom cost file to {snakemake.output.custom_cost_fn}.")
 
     combined.to_csv(snakemake.output.custom_cost_fn)
 

--- a/test/test_build_custom_cost_fn.py
+++ b/test/test_build_custom_cost_fn.py
@@ -4,15 +4,13 @@
 # For license information, see the LICENSE.txt file in the project root.
 """Unit tests for the custom cost file builder script."""
 
-from unittest.mock import MagicMock
+from importlib import import_module
 
 import pandas as pd
 import pytest
-from importlib import import_module
 
 main = import_module("scripts.pypsa-at.build_custom_cost_fn").main
 from scripts._helpers import mock_snakemake
-
 
 
 def test_combine_two_files_with_overlapping_entries_keeps_first(tmp_path):
@@ -80,6 +78,7 @@ def test_combine_two_files_with_overlapping_entries_keeps_first(tmp_path):
     # (2040, wind, capital_cost) from file 2 (no overlap)
     assert result.loc[(2040, "wind", "capital_cost"), "value"] == 300.0
 
+
 def test_duplicate_within_single_file_keeps_first_occurrence(tmp_path):
     """
     Test that duplicates within a single file are handled correctly:
@@ -115,6 +114,7 @@ def test_duplicate_within_single_file_keeps_first_occurrence(tmp_path):
     assert len(result) == 2
     assert result.loc[(2030, "solar", "capital_cost"), "value"] == 100.0
     assert result.loc[(2030, "wind", "capital_cost"), "value"] == 300.0
+
 
 def test_multiple_cost_columns_preserved(tmp_path):
     """
@@ -152,6 +152,7 @@ def test_multiple_cost_columns_preserved(tmp_path):
     assert set(result.columns) == {"value", "unit", "source"}
     assert result.loc[(2030, "solar", "capital_cost"), "unit"] == "EUR/kW"
     assert result.loc[(2030, "solar", "capital_cost"), "source"] == "DEA 2024"
+
 
 def test_empty_file_list_raises_error(tmp_path):
     """

--- a/test/test_build_custom_cost_fn.py
+++ b/test/test_build_custom_cost_fn.py
@@ -9,9 +9,9 @@ from importlib import import_module
 import pandas as pd
 import pytest
 
-main = import_module("scripts.pypsa-at.build_custom_cost_fn").main
 from scripts._helpers import mock_snakemake
 
+main = import_module("scripts.pypsa-at.build_custom_cost_fn").main
 
 def test_combine_two_files_with_overlapping_entries_keeps_first(tmp_path):
     """

--- a/test/test_build_custom_cost_fn.py
+++ b/test/test_build_custom_cost_fn.py
@@ -13,6 +13,7 @@ from scripts._helpers import mock_snakemake
 
 main = import_module("scripts.pypsa-at.build_custom_cost_fn").main
 
+
 def test_combine_two_files_with_overlapping_entries_keeps_first(tmp_path):
     """
     Test that combining two CSV files retains the first file's values for

--- a/test/test_build_custom_cost_fn.py
+++ b/test/test_build_custom_cost_fn.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2026 Austrian Gas Grid Management AG
+#
+# SPDX-License-Identifier: MIT
+# For license information, see the LICENSE.txt file in the project root.
+"""Unit tests for the custom cost file builder script."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from importlib import import_module
+
+main = import_module("scripts.pypsa-at.build_custom_cost_fn").main
+from scripts._helpers import mock_snakemake
+
+
+
+def test_combine_two_files_with_overlapping_entries_keeps_first(tmp_path):
+    """
+    Test that combining two CSV files retains the first file's values for
+    duplicate index entries and discards the second file's values.
+
+    This verifies the core behavior: earlier files have priority.
+    """
+    # Create first CSV with entries for solar and wind.
+    csv1_path = tmp_path / "costs_1.csv"
+    csv1_data = pd.DataFrame(
+        {
+            "planning_horizon": [2030, 2030, 2050],
+            "technology": ["solar", "wind", "solar"],
+            "parameter": ["capital_cost", "capital_cost", "capital_cost"],
+            "value": [100.0, 200.0, 80.0],
+        }
+    )
+    csv1_data.to_csv(csv1_path, index=False)
+
+    # Create second CSV with overlapping and new entries.
+    # Overlapping: (2030, solar, capital_cost) and (2050, solar, capital_cost)
+    # New: (2040, wind, capital_cost)
+    csv2_path = tmp_path / "costs_2.csv"
+    csv2_data = pd.DataFrame(
+        {
+            "planning_horizon": [2030, 2050, 2040],
+            "technology": ["solar", "solar", "wind"],
+            "parameter": ["capital_cost", "capital_cost", "capital_cost"],
+            "value": [999.0, 888.0, 300.0],  # Different values for duplicates
+        }
+    )
+    csv2_data.to_csv(csv2_path, index=False)
+
+    # Create output path
+    output_path = tmp_path / "combined.csv"
+
+    # Create mock Snakemake object
+    snakemake = mock_snakemake("build_custom_cost_fn")
+    snakemake.input.custom_cost_files = [str(csv1_path), str(csv2_path)]
+    snakemake.output.custom_cost_fn = str(output_path)
+
+    # Call the actual function
+    main(snakemake)
+
+    # Read and verify output
+    result = pd.read_csv(output_path, index_col=[0, 1, 2])
+
+    # Verify no duplicates in the result.
+    assert result.index.is_unique, "Result should have no duplicate indices"
+
+    # Verify the result has 4 entries: 3 from file 1, 1 new from file 2.
+    assert len(result) == 4, f"Expected 4 entries, got {len(result)}"
+
+    # Verify first file's values are retained for overlapping entries.
+    # (2030, solar, capital_cost) should be 100.0, not 999.0
+    assert result.loc[(2030, "solar", "capital_cost"), "value"] == 100.0
+    # (2050, solar, capital_cost) should be 80.0, not 888.0
+    assert result.loc[(2050, "solar", "capital_cost"), "value"] == 80.0
+
+    # Verify unique entries from both files are present.
+    # (2030, wind, capital_cost) from file 1
+    assert result.loc[(2030, "wind", "capital_cost"), "value"] == 200.0
+    # (2040, wind, capital_cost) from file 2 (no overlap)
+    assert result.loc[(2040, "wind", "capital_cost"), "value"] == 300.0
+
+def test_duplicate_within_single_file_keeps_first_occurrence(tmp_path):
+    """
+    Test that duplicates within a single file are handled correctly:
+    only the first occurrence is retained.
+    """
+    # Create a CSV with duplicate entries (same index, different values).
+    csv_path = tmp_path / "costs_duplicates.csv"
+    csv_data = pd.DataFrame(
+        {
+            "planning_horizon": [2030, 2030, 2030],
+            "technology": ["solar", "solar", "wind"],
+            "parameter": ["capital_cost", "capital_cost", "capital_cost"],
+            "value": [100.0, 200.0, 300.0],
+        }
+    )
+    csv_data.to_csv(csv_path, index=False)
+
+    # Create output path
+    output_path = tmp_path / "deduplicated.csv"
+
+    # Create mock Snakemake object
+    snakemake = mock_snakemake("build_custom_cost_fn")
+    snakemake.input.custom_cost_files = [str(csv_path)]
+    snakemake.output.custom_cost_fn = str(output_path)
+
+    # Call the actual function
+    main(snakemake)
+
+    # Read and verify output
+    result = pd.read_csv(output_path, index_col=[0, 1, 2])
+
+    # Verify only 2 entries: first solar (100.0) and wind (300.0).
+    assert len(result) == 2
+    assert result.loc[(2030, "solar", "capital_cost"), "value"] == 100.0
+    assert result.loc[(2030, "wind", "capital_cost"), "value"] == 300.0
+
+def test_multiple_cost_columns_preserved(tmp_path):
+    """
+    Test that all columns beyond the index are preserved during combination.
+    """
+    # Create CSV with multiple cost-related columns.
+    csv_path = tmp_path / "costs_multi.csv"
+    csv_data = pd.DataFrame(
+        {
+            "planning_horizon": [2030, 2050],
+            "technology": ["solar", "wind"],
+            "parameter": ["capital_cost", "capital_cost"],
+            "value": [100.0, 200.0],
+            "unit": ["EUR/kW", "EUR/kW"],
+            "source": ["DEA 2024", "DEA 2024"],
+        }
+    )
+    csv_data.to_csv(csv_path, index=False)
+
+    # Create output path
+    output_path = tmp_path / "output.csv"
+
+    # Create mock Snakemake object
+    snakemake = mock_snakemake("build_custom_cost_fn")
+    snakemake.input.custom_cost_files = [str(csv_path)]
+    snakemake.output.custom_cost_fn = str(output_path)
+
+    # Call the actual function
+    main(snakemake)
+
+    # Read and verify output
+    result = pd.read_csv(output_path, index_col=[0, 1, 2])
+
+    # Verify that non-index columns are preserved.
+    assert set(result.columns) == {"value", "unit", "source"}
+    assert result.loc[(2030, "solar", "capital_cost"), "unit"] == "EUR/kW"
+    assert result.loc[(2030, "solar", "capital_cost"), "source"] == "DEA 2024"
+
+def test_empty_file_list_raises_error(tmp_path):
+    """
+    Test that an empty file list raises ValueError.
+
+    In practice, Snakemake ensures at least one input file, so this
+    behavior is documented but not expected to occur in normal operation.
+    """
+    # Create output path
+    output_path = tmp_path / "output.csv"
+
+    # Create mock Snakemake object with empty input list
+    snakemake = mock_snakemake("build_custom_cost_fn")
+    snakemake.input.custom_cost_files = []
+    snakemake.output.custom_cost_fn = str(output_path)
+
+    # Calling main with empty file list raises ValueError from pd.concat
+    with pytest.raises(ValueError, match="No objects to concatenate"):
+        main(snakemake)


### PR DESCRIPTION
closes https://github.com/AGGM-AG/pypsa-at-planning/issues/244

## Changes proposed in this Pull Request

Problem:
The `costs/custom_cost_fn` in PyPSA-AT differs from the one in PyPSA-DE. However we want the information from both files for our cost. 

Implementation:
A new config option has been added to pass a list of cost_files. A new rule+script has been added to combine the listed cost files into a common resource file to be used for cost-processing rules. 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [ ] A brief description of the changes has been added to `Changelog.md`.
- [ ] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [ ] All github actions succeed.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `docs-at/` files.

## Summary by Sourcery

Add support for combining multiple custom cost CSV files into a unified resource for PyPSA-AT and route cost processing to use this combined file.

New Features:
- Introduce a configurable option to use either a single custom cost file or a list of cost files for cost processing.
- Add a Snakemake rule and script that build a consolidated custom cost resource CSV from one or more input cost files, with deterministic precedence.
- Patch the electricity build workflow so the cost processing rule consumes the generated unified custom cost file instead of a single input file.

Tests:
- Add unit tests covering combination logic, duplicate handling, column preservation, and error behavior when no input cost files are provided.