### PR TITLE
fix: correct link to docs in upstream file - remove html suffix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,5 @@ Before asking for a review for this PR make sure to complete the following check
 
 **If applicable:**
 - [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
-- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
+- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources) have been followed.
 - [ ] New rules are documented in the appropriate `docs-at/` files.


### PR DESCRIPTION
## Changes proposed in this Pull Request
Fix the link to the data sources update PyPSA-Eur docs. The link with html suffix opens a broken page. Its fine without.

Good: https://pypsa-eur.readthedocs.io/en/latest/data_sources/ 
Broken: https://pypsa-eur.readthedocs.io/en/latest/data_sources.html

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [ ] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [ ] All github actions succeed.

## Summary by Sourcery

Documentation:
- Update the PR template checklist to reference the correct PyPSA-Eur data sources documentation URL without the broken .html suffix.