### PR TITLE
Fix/add test for gas network data

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,5 @@ Before asking for a review for this PR make sure to complete the following check
 
 **If applicable:**
 - [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
-- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
+- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources) have been followed.
 - [ ] New rules are documented in the appropriate `docs-at/` files.

--- a/CHANGELOG.AT.md
+++ b/CHANGELOG.AT.md
@@ -49,3 +49,4 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed double subtraction of brownfield capacities in `modify_prenetwork` and `solve_network` and added a new test for this case. ([#101](https://github.com/AGGM-AG/pypsa-at/pull/101))
 - Fixed bidirectional links of gaseous energy carriers via config.at.yaml. Will be in an upstream merge to PyPSA-Eur to fix there. ([#105](https://github.com/AGGM-AG/pypsa-at/pull/105))
 - Fixed issues with wrong bus matching for h2 imports ([#134](https://github.com/AGGM-AG/pypsa-at/pull/134))
+- Fixed tests for integration of brownfield gas pipeline data ([#159](https://github.com/AGGM-AG/pypsa-at/pull/159))

--- a/config/config.at.yaml
+++ b/config/config.at.yaml
@@ -3,7 +3,7 @@
 #   * calibrations
 
 run:
-  prefix: update-inflow
+  prefix: 00_pypsa-at-vanilla
   name:
   - AT_KN2040
   scenarios:

--- a/mods/utils.py
+++ b/mods/utils.py
@@ -247,6 +247,7 @@ def attach_resources_to_network_meta(n: Network, snakemake: Snakemake) -> None:
         "co2_totals": lambda path: pd.read_csv(path, index_col=0).to_dict(
             orient="tight"
         ),
+        "aggm_gas_pipeline_data": lambda path: pd.read_csv(path, index_col=0).to_dict(),
         "inflow_data": lambda path: (
             xr.open_dataarray(path)
             .assign_coords(time=lambda ds: pd.to_datetime(ds.time.values).astype(str))

--- a/rules/pypsa-at/solve.smk
+++ b/rules/pypsa-at/solve.smk
@@ -9,6 +9,7 @@ Solve rule extensions for AT-specific datasets.
 RESOURCE_META = {
     "inflow_data": resources("inflow_per_region_{clusters}.nc"),
     "co2_totals": resources("co2_totals.csv"),
+    "aggm_gas_pipeline_data": resources("gas_network_base_s_{clusters}.csv"),
 }
 INPUT_META = [
     "energy_totals",

--- a/scripts/pypsa-at/modify_brownfield_gas_network_AT.py
+++ b/scripts/pypsa-at/modify_brownfield_gas_network_AT.py
@@ -60,7 +60,7 @@ def update_gas_transport_data(
         )
     ]
 
-    return pd.concat([raw, input_data], ignore_index=True)
+    return pd.concat([raw, input_data])
 
 
 if __name__ == "__main__":
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     custom_clustering = mods["modify_nuts3_shapes"]
 
     gas_network_raw = snakemake.input.clustered_gas_network_raw
-    gas_network_raw_df = pd.read_csv(gas_network_raw)
+    gas_network_raw_df = pd.read_csv(gas_network_raw, index_col=0)
 
     if mods["modify_brownfield_gas_network_AT"]:
         if custom_clustering.startswith("AT10"):
@@ -96,7 +96,7 @@ if __name__ == "__main__":
                 f"Unexpected clustering detected: {custom_clustering}. "
                 f"Chose from {('AT10DE5', 'AT35DE5')}."
             )
-        gas_network_input_df = pd.read_csv(gas_network_input)
+        gas_network_input_df = pd.read_csv(gas_network_input, index_col=0)
 
         # update data in raw where AGGM data is supplied
         new_gas_network_df = update_gas_transport_data(
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         )
 
         # return updated dataset
-        new_gas_network_df.to_csv(snakemake.output.clustered_gas_network, index=False)
+        new_gas_network_df.to_csv(snakemake.output.clustered_gas_network)
 
         logger.info("Modified Austrian gas network with AGGM input data.")
 

--- a/test/test_mods/network/test_gas.py
+++ b/test/test_mods/network/test_gas.py
@@ -301,22 +301,40 @@ class TestBrownfieldGasNetworkLinks:
         gas_pipes = links[links["carrier"] == "gas pipeline"]
         return gas_pipes[~gas_pipes.index.str.endswith("-reversed")]
 
-    def test_every_corridor_is_built(self, gas_pipelines, aggm_data):
-        """Every AGGM transport corridor exists as a Link in the brownfield network."""
-        missing = set(aggm_data.index) - set(gas_pipelines.index)
+    @pytest.fixture(scope="class")
+    def expected_corridors(self, brownfield_network, aggm_data) -> pd.DataFrame:
+        """
+        To conform to reduced country scope (eg. in CI test runs), drop busses
+        that are outside the modeled regions from expected corridors.
+        """
+        gas_buses = set(
+            brownfield_network.buses.index[brownfield_network.buses["carrier"] == "gas"]
+        )
+        in_scope = aggm_data.apply(
+            lambda c: {f"{c.bus0} gas", f"{c.bus1} gas"} <= gas_buses, axis=1
+        )
+        expected = aggm_data[in_scope]
+        assert not expected.empty, "No AGGM corridors within the modeled scope."
+        return expected
+
+    def test_every_corridor_is_built(self, gas_pipelines, expected_corridors):
+        """Every in-scope AGGM corridor exists as a Link in the brownfield network."""
+        missing = set(expected_corridors.index) - set(gas_pipelines.index)
         assert not missing, f"AGGM corridors missing from brownfield network: {missing}"
 
-    def test_corridors_connect_the_expected_buses(self, gas_pipelines, aggm_data):
+    def test_corridors_connect_the_expected_buses(
+        self, gas_pipelines, expected_corridors
+    ):
         """Each AGGM corridor connects the gas buses of its AGGM bus pair."""
-        built = gas_pipelines.loc[aggm_data.index]
+        built = gas_pipelines.loc[expected_corridors.index]
 
-        assert (built["bus0"] == aggm_data["bus0"] + " gas").all()
-        assert (built["bus1"] == aggm_data["bus1"] + " gas").all()
+        assert (built["bus0"] == expected_corridors["bus0"] + " gas").all()
+        assert (built["bus1"] == expected_corridors["bus1"] + " gas").all()
 
-    def test_capacities_are_built(self, gas_pipelines, aggm_data):
+    def test_capacities_are_built(self, gas_pipelines, expected_corridors):
         """Every AGGM transport capacity is present as Link capacity in brownfield network."""
-        built = gas_pipelines.loc[aggm_data.index, "p_nom"]
+        built = gas_pipelines.loc[expected_corridors.index, "p_nom"]
 
         pd.testing.assert_series_equal(
-            built, aggm_data["p_nom"], check_names=False, check_dtype=False
+            built, expected_corridors["p_nom"], check_names=False, check_dtype=False
         )

--- a/test/test_mods/network/test_gas.py
+++ b/test/test_mods/network/test_gas.py
@@ -4,9 +4,11 @@
 # For license information, see the LICENSE.txt file in the project root.
 """Integration tests for mods/network/gas.py — gas storage capacity overrides."""
 
+import pathlib
 from importlib import import_module
 
 import pandas as pd
+import pypsa
 import pytest
 from pypsa import NetworkCollection
 
@@ -252,7 +254,7 @@ class TestAGGMGasNetworkCapacityData:
         assert p_nom.notna().all()
         assert (p_nom >= 0).all()
 
-    def test_capacities_are_added(self, raw, aggm_data):
+    def test_capacities_are_added_to_csv(self, raw, aggm_data):
         """All AGGM capacities are actually added to the clustered gas network csv."""
         result = update_gas_transport_data(raw, aggm_data)
 
@@ -270,3 +272,51 @@ class TestAGGMGasNetworkCapacityData:
         result = update_gas_transport_data(raw, aggm_data)
 
         assert len(result) == foreign_corridors + len(aggm_data)
+
+
+@pytest.mark.AT
+class TestBrownfieldGasNetworkLinks:
+    """Verify the AGGM transport corridor capacities reach the brownfield"""
+
+    @pytest.fixture(scope="class")
+    def brownfield_network(self, result_path) -> pypsa.Network:
+        resources_path = pathlib.Path("resources", *result_path.parts[-2:])
+        network_path = (
+            resources_path / "networks" / "base_s_adm__none_2025_brownfield.nc"
+        )
+        return pypsa.Network(network_path)
+
+    @pytest.fixture(scope="class")
+    def aggm_data(self, brownfield_network, project_root) -> pd.DataFrame:
+        """AGGM data of the custom clustering the brownfield network was built with."""
+        mods = brownfield_network.meta["mods"]
+        clustering = mods["modify_nuts3_shapes"][:4]
+        file_name = f"AGGM_gas_network_base_{clustering}.csv"
+        return pd.read_csv(project_root / "data" / "pypsa-at" / file_name, index_col=0)
+
+    @pytest.fixture(scope="class")
+    def gas_pipelines(self, brownfield_network) -> pd.DataFrame:
+        """Gas pipeline Links of the brownfield network."""
+        links = brownfield_network.links
+        gas_pipes = links[links["carrier"] == "gas pipeline"]
+        return gas_pipes[~gas_pipes.index.str.endswith("-reversed")]
+
+    def test_every_corridor_is_built(self, gas_pipelines, aggm_data):
+        """Every AGGM transport corridor exists as a Link in the brownfield network."""
+        missing = set(aggm_data.index) - set(gas_pipelines.index)
+        assert not missing, f"AGGM corridors missing from brownfield network: {missing}"
+
+    def test_corridors_connect_the_expected_buses(self, gas_pipelines, aggm_data):
+        """Each AGGM corridor connects the gas buses of its AGGM bus pair."""
+        built = gas_pipelines.loc[aggm_data.index]
+
+        assert (built["bus0"] == aggm_data["bus0"] + " gas").all()
+        assert (built["bus1"] == aggm_data["bus1"] + " gas").all()
+
+    def test_capacities_are_built(self, gas_pipelines, aggm_data):
+        """Every AGGM transport capacity is present as Link capacity in brownfield network."""
+        built = gas_pipelines.loc[aggm_data.index, "p_nom"]
+
+        pd.testing.assert_series_equal(
+            built, aggm_data["p_nom"], check_names=False, check_dtype=False
+        )

--- a/test/test_mods/network/test_gas.py
+++ b/test/test_mods/network/test_gas.py
@@ -4,7 +4,6 @@
 # For license information, see the LICENSE.txt file in the project root.
 """Integration tests for mods/network/gas.py — gas storage capacity overrides."""
 
-import pathlib
 from importlib import import_module
 
 import pandas as pd
@@ -190,29 +189,18 @@ class TestModifyBrownfieldGasNetworkAT:
             ]
         )
 
-    def test_at_removed_from_raw(self, raw, input_data):
-        """Raw corridors touching Austria are dropped, no matter the bus position."""
-        result = update_gas_transport_data(raw, input_data)
-
-        assert not result["name"].str.startswith("sci2grid_at").any()
-        assert "sci2grid_border_at" not in set(result["name"])
-
-    def test_foreign_corridors_are_preserved_in_raw(self, raw, input_data):
-        """Corridors without an AT bus pass through unchanged."""
+    @pytest.fixture
+    def expected_output(self, raw, input_data) -> pd.DataFrame:
+        """Foreign corridors unchanged, AT corridors dropped, AGGM corridors appended."""
         foreign = ["sci2grid_de_internal", "sci2grid_sk_hu"]
+        expected_foreign = raw[raw["name"].isin(foreign)]
+        return pd.concat([expected_foreign, input_data])
 
+    def test_update_gas_transport_data(self, raw, input_data, expected_output):
+        """AT corridors dropped from raw, foreign corridors preserved, AGGM corridors added."""
         result = update_gas_transport_data(raw, input_data)
 
-        out = result[result["name"].isin(foreign)]
-        expected = raw[raw["name"].isin(foreign)]
-        assert out.compare(expected).empty
-
-    def test_input_at_corridors_are_added(self, raw, input_data):
-        """Check that all AGGM provided transport corridors are added"""
-        result = update_gas_transport_data(raw, input_data)
-
-        out = result[result["name"].str.startswith("AGGM_")]
-        assert out.compare(input_data).empty
+        pd.testing.assert_frame_equal(result, expected_output)
 
 
 class TestAGGMGasNetworkCapacityData:
@@ -274,25 +262,21 @@ class TestAGGMGasNetworkCapacityData:
         assert len(result) == foreign_corridors + len(aggm_data)
 
 
-@pytest.mark.AT
 class TestBrownfieldGasNetworkLinks:
     """Verify the AGGM transport corridor capacities reach the brownfield"""
 
     @pytest.fixture(scope="class")
-    def brownfield_network(self, result_path) -> pypsa.Network:
-        resources_path = pathlib.Path("resources", *result_path.parts[-2:])
-        network_path = (
-            resources_path / "networks" / "base_s_adm__none_2025_brownfield.nc"
-        )
-        return pypsa.Network(network_path)
+    def brownfield_network(self, nc) -> pypsa.Network:
+        """Solved 2025 network — topology (Links, buses) matches the pre-solve brownfield build."""
+        return nc.networks["2025"]
 
     @pytest.fixture(scope="class")
-    def aggm_data(self, brownfield_network, project_root) -> pd.DataFrame:
-        """AGGM data of the custom clustering the brownfield network was built with."""
-        mods = brownfield_network.meta["mods"]
-        clustering = mods["modify_nuts3_shapes"][:4]
-        file_name = f"AGGM_gas_network_base_{clustering}.csv"
-        return pd.read_csv(project_root / "data" / "pypsa-at" / file_name, index_col=0)
+    def aggm_data(self, brownfield_network) -> pd.DataFrame:
+        """AGGM corridors of the merged gas network resource attached to the solved network's meta."""
+        merged = pd.DataFrame.from_dict(
+            brownfield_network.meta["resources"]["aggm_gas_pipeline_data"]
+        )
+        return merged[merged["name"].str.startswith("AGGM_")]
 
     @pytest.fixture(scope="class")
     def gas_pipelines(self, brownfield_network) -> pd.DataFrame:

--- a/test/test_mods/network/test_gas.py
+++ b/test/test_mods/network/test_gas.py
@@ -272,11 +272,16 @@ class TestBrownfieldGasNetworkLinks:
 
     @pytest.fixture(scope="class")
     def aggm_data(self, brownfield_network) -> pd.DataFrame:
-        """AGGM corridors of the merged gas network resource attached to the solved network's meta."""
+        """
+        Raw corridors touching AT are all dropped by update_gas_transport_data.
+        Any AT corridor left in the merged resource originates from the AGGM input data.
+        """
         merged = pd.DataFrame.from_dict(
             brownfield_network.meta["resources"]["aggm_gas_pipeline_data"]
         )
-        return merged[merged["name"].str.startswith("AGGM_")]
+        at_bus0 = merged["bus0"].str.startswith("AT")
+        at_bus1 = merged["bus1"].str.startswith("AT")
+        return merged[at_bus0 | at_bus1]
 
     @pytest.fixture(scope="class")
     def gas_pipelines(self, brownfield_network) -> pd.DataFrame:

--- a/test/test_mods/network/test_gas.py
+++ b/test/test_mods/network/test_gas.py
@@ -4,6 +4,8 @@
 # For license information, see the LICENSE.txt file in the project root.
 """Integration tests for mods/network/gas.py — gas storage capacity overrides."""
 
+from importlib import import_module
+
 import pandas as pd
 import pytest
 from pypsa import NetworkCollection
@@ -12,6 +14,32 @@ from evals.utils import filter_by
 from mods.clustering.utils import combine_regions_by_clustering
 from mods.network.gas import _TANAP_PIPELINE_CAPACITY
 from test.conftest import require_config
+
+update_gas_transport_data = import_module(
+    "scripts.pypsa-at.modify_brownfield_gas_network_AT"
+).update_gas_transport_data
+
+GAS_NETWORK_COLUMNS = [
+    "bus0",
+    "bus1",
+    "p_nom",
+    "p_nom_diameter",
+    "max_pressure_bar",
+    "build_year",
+    "diameter_mm",
+    "length",
+    "name",
+    "p_min_pu",
+]
+
+
+def gas_network(rows: list[tuple[str, str, float, str]]) -> pd.DataFrame:
+    """Build a gas network DataFrame from (bus0, bus1, p_nom, name) rows."""
+    df = pd.DataFrame(rows, columns=["bus0", "bus1", "p_nom", "name"])
+    for column in GAS_NETWORK_COLUMNS:
+        if column not in df:
+            df[column] = 0
+    return df[GAS_NETWORK_COLUMNS]
 
 
 def test_gas_storage_update(nc, project_root, is_testrun):
@@ -129,3 +157,114 @@ def test_block_russian_gas_imports(nc, block_name):
     assert pipeline_supply.sum() == 0, (
         f"Remaining pipeline imports detected: {pipeline_supply}"
     )
+
+
+class TestModifyBrownfieldGasNetworkAT:
+    """Unit tests for adding AGGM brownfield gas grid"""
+
+    @pytest.fixture
+    def raw(self) -> pd.DataFrame:
+        """Clustered gas network as built by PyPSA-Eur standard from Sci2Grid data."""
+        return gas_network(
+            [
+                ("AT12", "AT13", 19616.0, "sci2grid_at_internal"),
+                ("AT12", "SI", 4689.0, "sci2grid_at_border"),
+                ("SK", "AT12", 96080.0, "sci2grid_border_at"),
+                ("DE1", "DE2", 12000.0, "sci2grid_de_internal"),
+                ("SK", "HU", 8000.0, "sci2grid_sk_hu"),
+            ]
+        )
+
+    @pytest.fixture
+    def input_data(self) -> pd.DataFrame:
+        """Mock AGGM expert data for Austrian transport corridors."""
+        return gas_network(
+            [
+                ("AT12", "AT13", 1234.0, "AGGM_pipeline01"),
+                ("AT12", "SI", 4500.0, "AGGM_pipeline02"),
+                ("SK", "AT12", 65300.0, "AGGM_pipeline03"),
+            ]
+        )
+
+    def test_at_removed_from_raw(self, raw, input_data):
+        """Raw corridors touching Austria are dropped, no matter the bus position."""
+        result = update_gas_transport_data(raw, input_data)
+
+        assert not result["name"].str.startswith("sci2grid_at").any()
+        assert "sci2grid_border_at" not in set(result["name"])
+
+    def test_foreign_corridors_are_preserved_in_raw(self, raw, input_data):
+        """Corridors without an AT bus pass through unchanged."""
+        foreign = ["sci2grid_de_internal", "sci2grid_sk_hu"]
+
+        result = update_gas_transport_data(raw, input_data)
+
+        out = result[result["name"].isin(foreign)].reset_index(drop=True)
+        expected = raw[raw["name"].isin(foreign)].reset_index(drop=True)
+        assert out.compare(expected).empty
+
+    def test_input_at_corridors_are_added(self, raw, input_data):
+        """Check that all AGGM provided transport corridors are added"""
+        result = update_gas_transport_data(raw, input_data)
+
+        out = result[result["name"].str.startswith("AGGM_")].reset_index(drop=True)
+        assert out.compare(input_data).empty
+
+
+class TestAGGMGasNetworkCapacityData:
+    """Data integrity tests for the AGGM brownfield gas network capacity input files."""
+
+    @pytest.fixture(params=["AT10", "AT35"])
+    def aggm_data(self, request, project_root) -> pd.DataFrame:
+        """AGGM brownfield gas network for both supported custom clusterings is present."""
+        file_name = f"AGGM_gas_network_base_{request.param}.csv"
+        return pd.read_csv(project_root / "data" / "pypsa-at" / file_name, index_col=0)
+
+    @pytest.fixture
+    def raw(self) -> pd.DataFrame:
+        """
+        Mock network that contains every bus that borders AT regions
+        (Germany DE1, DE2, CH, IT0, SI, HU, SK, CZ)
+        """
+        return gas_network(
+            [
+                ("DE1", bus, 1.0, f"sci2grid_DE1_{bus}")
+                for bus in ["DE2", "CH", "IT0", "SI", "HU", "SK", "CZ"]
+            ]
+            + [("AT12", "AT13", 19616.0, "sci2grid_at_internal")]
+        )
+
+    def test_columns(self, aggm_data):
+        """The AGGM data provides exactly the columns of a PyPSA gas network."""
+        assert list(aggm_data.columns) == GAS_NETWORK_COLUMNS
+
+    def test_corridors_are_unique(self, aggm_data):
+        """Check that each corridor index and name are unique."""
+        assert aggm_data.index.is_unique
+        assert aggm_data["name"].is_unique
+
+    def test_capacities_are_valid(self, aggm_data):
+        """Transport capacities are numeric, non-negative and not NaN"""
+        p_nom = aggm_data["p_nom"]
+        assert pd.api.types.is_numeric_dtype(p_nom)
+        assert p_nom.notna().all()
+        assert (p_nom >= 0).all()
+
+    def test_capacities_are_added(self, raw, aggm_data):
+        """All AGGM capacities are actually added to the clustered gas network csv."""
+        result = update_gas_transport_data(raw, aggm_data)
+
+        at_bus0 = result["bus0"].str.startswith("AT")
+        at_bus1 = result["bus1"].str.startswith("AT")
+        at_capacity = result.loc[at_bus0 | at_bus1, "p_nom"].sum()
+        assert at_capacity == pytest.approx(aggm_data["p_nom"].sum())
+
+    def test_corridor_count(self, raw, aggm_data):
+        """The new file contains all raw non-AT capacities plus all added AGGM AT capacities."""
+        at_bus0 = raw["bus0"].str.startswith("AT")
+        at_bus1 = raw["bus1"].str.startswith("AT")
+        foreign_corridors = (~(at_bus0 | at_bus1)).sum()
+
+        result = update_gas_transport_data(raw, aggm_data)
+
+        assert len(result) == foreign_corridors + len(aggm_data)

--- a/test/test_mods/network/test_gas.py
+++ b/test/test_mods/network/test_gas.py
@@ -39,6 +39,8 @@ def gas_network(rows: list[tuple[str, str, float, str]]) -> pd.DataFrame:
     for column in GAS_NETWORK_COLUMNS:
         if column not in df:
             df[column] = 0
+    # corridor identifiers are the index, as in the clustered gas network files
+    df.index = "gas pipeline " + df["bus0"] + " -> " + df["bus1"]
     return df[GAS_NETWORK_COLUMNS]
 
 
@@ -199,15 +201,15 @@ class TestModifyBrownfieldGasNetworkAT:
 
         result = update_gas_transport_data(raw, input_data)
 
-        out = result[result["name"].isin(foreign)].reset_index(drop=True)
-        expected = raw[raw["name"].isin(foreign)].reset_index(drop=True)
+        out = result[result["name"].isin(foreign)]
+        expected = raw[raw["name"].isin(foreign)]
         assert out.compare(expected).empty
 
     def test_input_at_corridors_are_added(self, raw, input_data):
         """Check that all AGGM provided transport corridors are added"""
         result = update_gas_transport_data(raw, input_data)
 
-        out = result[result["name"].str.startswith("AGGM_")].reset_index(drop=True)
+        out = result[result["name"].str.startswith("AGGM_")]
         assert out.compare(input_data).empty
 
 


### PR DESCRIPTION
closes https://github.com/AGGM-AG/pypsa-at-planning/issues/220

## Changes proposed in this Pull Request
Adds a test protocoll for the addition of AGGM approved gas pipeline brownfield that was added in https://github.com/AGGM-AG/pypsa-at/pull/91

#### Tests: 
- unit tests for `update_gas_transport_data()` function on synthetic dataframes, check if Austrian corridors are dropped and added correctly and non-Austrian corridors are not touched 
- integrity tests for `AGGM_gas_network_base_AT10.csv` and `AGGM_gas_network_base_AT35.csv`: unique identifiers, `p_nom` is numeric/non-negative/non-null, row count correct through merging with raw dataset 
- test Link building: in `base_s_adm__none_2025_brownfield.nc` check that `gas pipeline` Links of correct capacity are added to the correct AT buses. 

#### Additional fix: 
- changed a potential future indexing problem in `modify_brownfield_gas_network_AT.py` script 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A brief description of the changes has been added to `Changelog.md`.
- [x] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [ ] All github actions succeed.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources) have been followed.
- [ ] New rules are documented in the appropriate `docs-at/` files.

## Summary by Sourcery

Add tests and data plumbing to validate integration of AGGM brownfield gas pipeline data into clustered gas networks and brownfield solutions.

New Features:
- Add unit tests for updating clustered gas transport data with AGGM brownfield corridors using synthetic networks.
- Add integrity tests for AGGM gas network capacity CSVs for AT10 and AT35 clusterings, including uniqueness and capacity validations.
- Add integration tests verifying AGGM gas pipeline links and capacities are correctly built into the 2025 brownfield network and attached as resources metadata.

Bug Fixes:
- Preserve gas network indices by avoiding index reset when concatenating AGGM data with raw clustered gas networks.
- Ensure clustered gas network CSVs for AT brownfield modification are read and written with indices preserved, preventing future indexing issues.

Enhancements:
- Expose AGGM gas pipeline capacity CSVs as a network meta resource and wire them into the AT solve workflow.
- Update AT configuration run prefix for the pypsa-at vanilla scenario.
- Document the fix for brownfield gas pipeline integration tests in the AT changelog.

Tests:
- Introduce helper utilities for constructing synthetic gas network DataFrames used in new gas transport tests.