### PR TITLE
fix: add missing technology colors

### DIFF
--- a/config/plotting.at.yaml
+++ b/config/plotting.at.yaml
@@ -8,8 +8,14 @@
 # the final word on plotting values (see Snakefile).
 plotting:
   tech_colors:
-    # PHS is split into charger/discharger/store components in PyPSA-AT, so the
-    # upstream "PHS" rename key does not match. Colour them like PHS ('#51dbcc').
+    # PHS is split into charger/discharger/store/inflow components in PyPSA-AT, so
+    # the upstream "PHS" rename key does not match. Colour them like PHS ('#51dbcc').
     PHS charger: '#51dbcc'
     PHS discharger: '#51dbcc'
     PHS store: '#51dbcc'
+    PHS inflow: '#51dbcc'
+    # hydro reservoirs are likewise split into discharger/store/inflow components.
+    # Colour them like hydro ('#298c81').
+    hydro discharger: '#298c81'
+    hydro store: '#298c81'
+    hydro inflow: '#298c81'


### PR DESCRIPTION
## Changes proposed in this Pull Request
Fixes the `all` rule workflow after introduction of new technologies. 

```python
ERROR:root:Uncaught exception
Traceback (most recent call last):
  File "/mnt/storage/runs/AT_KN2040_AT35DE5_365H_main_20260715_020313/.snakemake/scripts/tmph1wkq7_z.plot_summary.py", line 511, in <module>
    plot_balances()
  File "/mnt/storage/runs/AT_KN2040_AT35DE5_365H_main_20260715_020313/.snakemake/scripts/tmph1wkq7_z.plot_summary.py", line 252, in plot_balances
    color=[snakemake.params.plotting["tech_colors"][i] for i in new_index],
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
KeyError: 'PHS inflow'
RuleException:
CalledProcessError in file "/mnt/storage/runs/AT_KN2040_AT35DE5_365H_main_20260715_020313/rules/postprocess.smk", line 462:
Command 'set -euo pipefail;  /mnt/storage/runs/AT_KN2040_AT35DE5_365H_main_20260715_020313/.pixi/envs/default/bin/python3.12 /mnt/storage/runs/AT_KN2040_AT35DE5_365H_main_20260715_020313/.snakemake/scripts/tmph1wkq7_z.plot_summary.py' returned non-zero exit status 1.
[Wed Jul 15 02:43:09 2026]
```

successful run on AGGM infrastructure: see pipeline job 1073

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [x] All github actions succeed.

## Summary by Sourcery

Add missing technology color mappings to fix plotting workflow failures when handling split PHS and hydro components.

Bug Fixes:
- Resolve KeyError in the summary plotting workflow by defining colors for the PHS inflow technology.

Enhancements:
- Align color configuration for newly split PHS and hydro reservoir components so plots consistently use PHS and hydro color schemes.