### PR TITLE
Fix infeasibility: pset=0 and trajectory limits 

### DIFF
--- a/mods/network/trajectories.py
+++ b/mods/network/trajectories.py
@@ -192,6 +192,18 @@ def apply_trajectories(
         elif at_port != 0:
             raise NotImplementedError(f"Value for 'at_port' {at_port} not implemented.")
 
+        # Keep existing brownfield capacities as lower boundary for
+        # base years to prevent model infeasibility
+        if not is_myopic_year:
+            installed = comp.loc[idx, "p_nom_min"].item()
+            if p_nom_max < installed:
+                logger.warning(
+                    f"Trajectory p_nom_max {p_nom_max:.2f} for {c} {idx} is below the "
+                    f"installed capacity {installed:.2f}. Raising p_nom_max to the "
+                    f"installed capacity."
+                )
+                p_nom_max = installed
+
         # Sanity check for calculated boundaries
         if (p_nom_max - p_nom_min) < 0:
             raise ValueError(

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -8,6 +8,7 @@ technologies for the buildings, transport and industry sectors.
 
 import logging
 import os
+from functools import partial
 from itertools import product
 from types import SimpleNamespace
 
@@ -6007,7 +6008,8 @@ aggregate_dict = {
     "v_ang_max": "min",
     "terrain_factor": "mean",
     "num_parallel": "sum",
-    "p_set": "sum",
+    # PyPSA-AT hotfix to keep NaN instead of zeros to prevent 0 bounded constraints
+    "p_set": partial(pd.Series.sum, min_count=1),
     "e_initial": "sum",
     "e_nom": pd.Series.sum,
     "e_nom_max": pd.Series.sum,

--- a/test/test_mods/constraints/test_constraints.py
+++ b/test/test_mods/constraints/test_constraints.py
@@ -557,7 +557,7 @@ def test_green_h2_constraint_statistics(nc, cc):
         supply = green_h2.xs(year)
         power_demand = h2_for_power.xs(year)
         fuel_demand = h2_for_fuel.xs(year)
-        assert supply.sum() + 1e-6 >= power_demand.sum() + fuel_demand.sum(), (
+        assert supply.sum() + 1e-4 >= power_demand.sum() + fuel_demand.sum(), (
             f"Year {year}, country {cc}: green H2 {supply.sum():.0f} MWh < "
             f"H2 for power {power_demand.sum():.0f} MWh + "
             f"H2 for fuel synthesis {fuel_demand.sum():.0f} MWh"


### PR DESCRIPTION
## Changes proposed in this Pull Request
Fixes 2 independent infeasibilities: 
1. PyPSA API changes replace aggregation logic, causing zeros in component attributes instead of previous NaN values. This adds 0-bounded constraints to the LP that caused the infeasibility. A hotfix in prepare_sector_network.py fixes that until the next upstream merge. 
2. The new mods trajectories feature set lower boundaries from input data sources for the base year as constraints. If existing base year capacities exceed the trajectory bounds, the model becomes infeasible. The fix clips trajectory boundaries to existing capacities. 

I check by running integration tests. Workflow runs still pending. 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [ ] All github actions succeed.

## Summary by Sourcery

Resolve model infeasibilities caused by trajectory lower bounds and PyPSA aggregation changes.

Bug Fixes:
- Ensure trajectory-based capacity upper bounds for base years are not set below existing installed capacities to avoid infeasible constraints.
- Preserve NaN values for p_set during aggregation instead of converting them to zeros to prevent unintended zero-bounded constraints in the optimization model.