### PR TITLE
Fix: add missing default result path to evals CLI

### DIFF
--- a/evals/cli.py
+++ b/evals/cli.py
@@ -39,6 +39,7 @@ $ pixi shell
 import copy
 import logging
 import sys
+from pathlib import Path
 from time import time
 
 import click
@@ -77,7 +78,9 @@ def cli() -> None:
 
 
 @cli.command()
-@click.argument("result_path", type=click.Path(exists=True), required=False)
+@click.argument(
+    "result_path", type=click.Path(path_type=Path, exists=True), required=False
+)
 @click.option(
     "--sub_directory",
     "-s",

--- a/evals/cli.py
+++ b/evals/cli.py
@@ -77,7 +77,7 @@ def cli() -> None:
 
 
 @cli.command()
-@click.argument("result_path", type=click.Path(exists=True), required=True)
+@click.argument("result_path", type=click.Path(exists=True), required=False)
 @click.option(
     "--sub_directory",
     "-s",
@@ -98,7 +98,7 @@ def cli() -> None:
     "--fail_fast", "-f", type=bool, multiple=False, required=False, default=False
 )
 def run_eval(
-    result_path: click.Path,
+    result_path: click.Path | None,
     sub_directory: str,
     names: list[str],
     config_override: str | None,
@@ -114,9 +114,9 @@ def run_eval(
     Parameters
     ----------
     result_path
-        The path to the result folder, usually ./pypsa-eur-sec/results.
-        Note that running on copied result folders might fail
-        due to missing resource files.
+        The path to the result folder, usually ./pypsa-at/results. Optional
+        — defaults to the most recently modified scenario folder below
+        ``./results``.
     sub_directory
         The subdirectory in the results folder that contains the network files.
     names
@@ -163,6 +163,10 @@ def run_eval(
     """
     import evals.views as views
     from evals.fileio import read_networks, read_views_config
+    from evals.utils import get_latest_results_folder
+
+    result_path = result_path or get_latest_results_folder()
+    logger.info(f"Running evaluations on results folder: {result_path.resolve()}")
 
     eval_functions = [
         getattr(views, fn) for fn in views.__all__ if (not names or fn in names)


### PR DESCRIPTION
## Changes proposed in this Pull Request
For some reason, the default result_path resolution is missing in main. This PR adds it again. 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [ ] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [ ] All github actions succeed.

## Summary by Sourcery

Make the evals CLI result path argument optional and default to the latest results folder when not provided.

New Features:
- Automatically select the most recently modified scenario results folder when no result path is specified in the evals CLI.

Enhancements:
- Improve CLI usability by allowing evaluations to run without explicitly specifying a result path and logging the resolved folder path.