### PR TITLE
Fix: gas storage location update

### DIFF
--- a/data/pypsa-at/gas_input_locations_s_AT35DE16_updated.csv
+++ b/data/pypsa-at/gas_input_locations_s_AT35DE16_updated.csv
@@ -1,10 +1,10 @@
 Region,lng (MWh/h),pipeline (MWh/h),production (MWh/h),storage (GWh),storage update (GWh),storage update source,storage update url
 AT125,,,,4696.071261,0,AGGM,
 AT126,,,1785.956709,29422.4,26770.98,OMV (Schönkirchen + Tallesbrunn combined),https://ocb-st.omv.com/ocb/app/
-AT311,,,,9392.142521,35984,RAG (Aigelsbrunn+Haidach5; Haidach RAG); SEFE (Haidach SEFE),https://www.rag-austria.at/rag-energiewelt/energie-speichern/leistungskennzahlen-der-speicher
+AT311,,,,9392.142521,0,AGGM,
 AT312,,,,4696.071261,0,AGGM,
 AT314,,,,4696.071261,0,AGGM,
-AT315,,,,6202.56,37500,RAG (Puchkirchen; Nussdorf Zagling); UNIPER (7 Fields EGS),https://www.rag-austria.at/rag-energiewelt/energie-speichern/leistungskennzahlen-der-speicher
+AT315,,,,6202.56,73484,RAG (Puchkirchen; Nussdorf Zagling; Aigelsbrunn+Haidach5; Haidach RAG); SEFE (Haidach SEFE); UNIPER (7 Fields EGS),https://www.rag-austria.at/rag-energiewelt/energie-speichern/leistungskennzahlen-der-speicher
 AT323,,,,28176.42756,0,AGGM,
 BE,20780.2224,18782.82855,,545.28,7610,Gas Infrastructure Europe - AGSI,https://agsi.gie.eu/
 BG,,17204.76303,,5680,7004.4,Gas Infrastructure Europe - AGSI,https://agsi.gie.eu/

--- a/mods/network/gas.py
+++ b/mods/network/gas.py
@@ -5,7 +5,6 @@
 """Gas-related pre-network modifications for the ``modify_prenetwork`` step."""
 
 from logging import getLogger
-from pathlib import Path
 
 import pandas as pd
 import pypsa
@@ -218,7 +217,7 @@ def override_gas_storage_capacities(n: pypsa.Network, snakemake: Snakemake) -> N
     """
     Override gas Store e_nom_min with validated storage capacities.
 
-    Reads ``data/pypsa-at/gas_input_locations_s_AT35DE16_updated.csv`` (AT NUTS3
+    Reads ``snakemake.input.gas_storage_capacities`` (AT NUTS3
     + DE NUTS1 resolution) and overwrites ``e_nom_min`` on all matched gas Store
     components. Aggregates to the network's actual bus resolution:
 
@@ -256,10 +255,9 @@ def override_gas_storage_capacities(n: pypsa.Network, snakemake: Snakemake) -> N
 
     logger.info("Overriding gas storage capacities.")
 
-    # prefer relative path over extending upstream pypsa-de snakemake rule
-    file_name = "gas_input_locations_s_AT35DE16_updated.csv"
-    file_path = Path(__file__).parents[2] / "data" / "pypsa-at" / file_name
-    storage = pd.read_csv(file_path, index_col=0)["storage update (GWh)"]
+    storage = pd.read_csv(snakemake.input.gas_storage_capacities, index_col=0)[
+        "storage update (GWh)"
+    ]
 
     # calculate total existing gas storage capacities
     total_previous = n.stores.query("carrier == 'gas'")["e_nom_min"].sum()

--- a/rules/pypsa-at/modify.smk
+++ b/rules/pypsa-at/modify.smk
@@ -130,6 +130,7 @@ use rule modify_prenetwork as modify_prenetwork_at with:
         gas_input_nodes_simplified=resources(
             "gas_input_locations_s_{clusters}_simplified.csv"
         ),
+        gas_storage_capacities="data/pypsa-at/gas_input_locations_s_AT35DE16_updated.csv",
         h2_imports_tyndp=branch(
             config_provider("sector", "h2_topology_tyndp"),
             resources("h2_import_potentials_{clusters}_{planning_horizons}.csv"),


### PR DESCRIPTION
solves https://github.com/AGGM-AG/pypsa-at-planning/issues/236 

## Changes proposed in this Pull Request
Gas storage locations needed relocation. Some storages geographically located in AT 315 are only connected to pipeline infrastructure at AT311.  
* the data file update relocates capacities 
* additionally, the function was refactored to take a rule input instead of constructing the input file path in the function body 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [ ] All github actions succeed.

## Summary by Sourcery

Update gas storage capacity handling to use a Snakemake rule input file instead of a hard-coded path, alongside refreshed gas storage capacity data for AT35/DE16.

Enhancements:
- Refactor gas storage override logic to read capacities from snakemake.input.gas_storage_capacities passed by the modify_prenetwork rule.
- Wire gas_storage_capacities into the pypsa-at modify_prenetwork Snakemake rule to configure the data source explicitly.

Build:
- Refresh the gas_input_locations_s_AT35DE16_updated.csv data file with corrected gas storage location capacities.