### PR TITLE
fix: apply clipping to inflow snapshot values in tests

### DIFF
--- a/test/test_mods/network/test_hydro.py
+++ b/test/test_mods/network/test_hydro.py
@@ -4,11 +4,55 @@
 
 """Test hydro inflow patching."""
 
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from pypsa import Network
 
 from test.conftest import require_config
+
+
+def _snapshot_profiles(
+    n: Network, inflow: xr.DataArray, carrier: str, suffix: str
+) -> pd.DataFrame:
+    """Aggregate the hourly PEMMDB inflow to the network snapshots (mean per bin)."""
+    profiles = inflow.sel(carrier=carrier).transpose("time", "countries").to_pandas()
+    time = profiles.index
+    edges = n.snapshots.append(pd.DatetimeIndex([time[-1] + pd.Timedelta(hours=1)]))
+    bins = pd.cut(time, bins=edges, labels=n.snapshots, right=False)
+    profiles = profiles.groupby(bins, observed=False).mean()
+    profiles.index = n.snapshots
+    profiles.columns = [f"{region} {suffix}" for region in profiles.columns]
+    return profiles.fillna(0.0)
+
+
+def _per_unit(profiles: pd.DataFrame, p_nom: pd.Series) -> pd.DataFrame:
+    """Convert absolute inflow profiles to per unit of nominal capacity."""
+    p_nom = p_nom.reindex(profiles.columns)
+    profiles = profiles.div(p_nom, axis=1)
+    return profiles.replace([np.inf, -np.inf], 0.0).fillna(0.0)
+
+
+def _energy(profiles: pd.DataFrame, weightings: pd.Series, clip: float) -> pd.Series:
+    """
+    Total inflow energy per component.
+
+    ``solve_network`` zeroes all profile values below ``solving.options.clip_p_max_pu``
+    (generator/link ``p_max_pu``/``p_min_pu`` and storage unit ``inflow``). The solved
+    networks therefore carry slightly less inflow energy than PEMMDB reports, which is
+    replicated here to compare like with like.
+    """
+    clipped = profiles.where(profiles.abs() > clip, other=0.0)
+    return clipped.mul(weightings, axis=0).sum()
+
+
+def _assert_energy_matches(actual: pd.Series, expected: pd.Series, tol: float) -> None:
+    """Compare inflow energies of all regions with an inflow timeseries."""
+    actual = actual.reindex(expected.index, fill_value=0.0)
+    actual.name = expected.name = "inflow"
+    actual.index.name = expected.index.name = None
+    pd.testing.assert_series_equal(actual, expected, check_exact=False, atol=tol)
 
 
 def test_inflows_match_pemmdb_totals(nc, project_root):
@@ -22,67 +66,52 @@ def test_inflows_match_pemmdb_totals(nc, project_root):
     if "hydro" not in renewable_carriers:
         pytest.skip("No hydro components in network, skipping")
 
+    clip = require_config(nc, "solving", "options", "clip_p_max_pu")
+
     for year, n in nc.networks.items():
         inflow = xr.DataArray.from_dict(n.meta["resources"]["inflow_data"])
         inflow = inflow.assign_coords(time=pd.to_datetime(inflow.time.values))
-        tol = 0.01 * n.snapshot_weightings.max()[0]
+        weightings = n.snapshot_weightings.stores
+        tol = 0.01 * n.snapshot_weightings.max().iloc[0]
 
         reservoirs_columns = n.storage_units.query('carrier == "hydro"').index
         reservoirs_actual = (
             n.storage_units_t.inflow.reindex(columns=reservoirs_columns, fill_value=0.0)
-            .mul(n.snapshot_weightings.stores, axis=0)
+            .mul(weightings, axis=0)
             .sum()
         )
-        reservoirs_expected = (
-            inflow.sel(carrier="hydro")
-            .sum(dim="time")
-            .to_dataframe(name="inflow")["inflow"]
+        reservoirs_expected = _energy(
+            _snapshot_profiles(n, inflow, "hydro", "hydro"), weightings, clip
         )
-        reservoirs_expected.index += " hydro"
-        reservoirs_actual = reservoirs_actual.reindex(
-            reservoirs_expected.index, fill_value=0.0
-        )
-        reservoirs_actual.name = "inflow"
-        pd.testing.assert_series_equal(
-            reservoirs_actual, reservoirs_expected, check_exact=False, atol=tol
-        )
+        _assert_energy_matches(reservoirs_actual, reservoirs_expected, tol)
 
         phs_columns = n.generators.query('carrier == "PHS inflow"').index
         phs_actual = (
             n.generators_t.p_max_pu.reindex(columns=phs_columns, fill_value=0.0)
-            .mul(n.snapshot_weightings.stores, axis=0)
+            .mul(weightings, axis=0)
             .sum()
         )
-        phs_expected = (
-            inflow.sel(carrier="PHS")
-            .sum(dim="time")
-            .to_dataframe(name="inflow")["inflow"]
+        phs_expected = _energy(
+            _per_unit(
+                _snapshot_profiles(n, inflow, "PHS", "PHS inflow"),
+                n.generators["p_nom"],
+            ),
+            weightings,
+            clip,
         )
-        phs_expected.index += " PHS inflow"
-        phs_expected /= n.generators.loc[phs_columns, "p_nom"].fillna(0)
-        phs_expected = phs_expected.fillna(0)
-        phs_actual = phs_actual.reindex(phs_expected.index, fill_value=0.0)
-        phs_actual.name = "inflow"
-        pd.testing.assert_series_equal(
-            phs_actual, phs_expected, check_exact=False, atol=tol
-        )
+        _assert_energy_matches(phs_actual, phs_expected, tol)
 
         ror_columns = n.generators.query('carrier == "ror"').index
         ror_actual = (
             n.generators_t.p_max_pu.reindex(columns=ror_columns, fill_value=0.0)
-            .mul(n.snapshot_weightings.stores, axis=0)
+            .mul(weightings, axis=0)
             .sum()
         )
-        ror_expected = (
-            inflow.sel(carrier="ror")
-            .sum(dim="time")
-            .to_dataframe(name="inflow")["inflow"]
+        ror_expected = _energy(
+            _per_unit(
+                _snapshot_profiles(n, inflow, "ror", "ror"), n.generators["p_nom"]
+            ),
+            weightings,
+            clip,
         )
-        ror_expected.index += " ror"
-        ror_expected /= n.generators.loc[ror_columns, "p_nom"]
-        ror_expected = ror_expected.fillna(0)
-        ror_actual = ror_actual.reindex(ror_expected.index, fill_value=0.0)
-        ror_actual.name = "inflow"
-        pd.testing.assert_series_equal(
-            ror_actual, ror_expected, check_exact=False, atol=tol
-        )
+        _assert_energy_matches(ror_actual, ror_expected, tol)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Introduces clipping applied to snapshot values via `renewable.onwind.clip_p_max_pu` (0.01 by default in config.default,yaml) that sets smalle values in `generators_t.p_max_pu`, `p_min_pu`, `links_t.*` and `storage_units_t.inflow` to zero. This was not done in the test and caused the PHS inflows in Portugal to be off by 3.3836 MWh. 

The fix introduces the clipping in test calculations for the `expected` side. This effectively applies clipping to `actual` values from the network via the snakemake workflow and to the `expected` values reconstructed in the test. 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] All Sourcery Bot review suggestions have been implemented or discarded with an explanation.
- [x] All github actions succeed.

## Summary by Sourcery

Align hydro inflow tests with network clipping behaviour when comparing PEMMDB-derived inflow to solved network results.

Enhancements:
- Factor out shared inflow processing into helper utilities for snapshot aggregation, per-unit conversion, energy calculation, and assertion of energy matches.

Tests:
- Apply the configured inflow clipping threshold in hydro inflow comparison tests so expected inflow energy matches clipped values in solved networks.
- Use snapshot weightings and per-unit conversions consistently across hydro reservoir, PHS inflow, and run-of-river inflow tests.